### PR TITLE
remove ExpressionSet2MRexperiment references

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metavizr
 Type: Package
-Version: 1.7.3
+Version: 1.7.4
 Authors@R: c( person("Hector", "Corrada Bravo",
         email="hcorrada@gmail.com", role=c("cre","aut")),
         person("Florin", "Chelaru", email="florin.chelaru@gmail.com",
@@ -28,7 +28,7 @@ Depends: R (>= 3.4), metagenomeSeq (>= 1.17.1), methods, data.table,
 Imports: epivizr, epivizrData, epivizrServer, epivizrStandalone, vegan,
         GenomeInfoDb, phyloseq, httr
 Suggests: knitr, BiocStyle, matrixStats, msd16s (>= 0.109.1), etec16s,
-        testthat, gss, curatedMetagenomicData
+        testthat, gss, ExperimentHub, tidyr, rmarkdown
 Collate: 'metavizControl.R' 'startMetaviz.R' 'utils.R'
         'EpivizMetagenomicsData-class.R' 'register-methods.R'
         'validateMRExperiment.R' 'MetavizApp-class.R'

--- a/tests/testthat/test-EpivizMetagenomicsInnerNodeData_class.R
+++ b/tests/testthat/test-EpivizMetagenomicsInnerNodeData_class.R
@@ -1,18 +1,64 @@
 context("testing EpivizMetagenomicsInnerNodesData Class")
-library(curatedMetagenomicData)
+library(tidyr)
 
 # From curatedMetagenomicData and MicrobiomeWorkshop Vignettes
 loman_file <- system.file("extdata", "loman.RData", package = "metavizr")
 load(loman_file)
 loman.eset <- loman[[1]]
-loman_MR <- ExpressionSet2MRexperiment(loman.eset)
+
+relative_abundance <-
+  exprs(loman.eset)
+
+number_reads <-
+  loman.eset$number_reads
+
+counts <-
+  sweep(relative_abundance, 2, number_reads/100, "*")
+
+counts <-
+  round(counts)
+
+pheno_data <-
+  phenoData(loman.eset)
+
+into_cols <-
+  c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species", "Strain")
+
+taxonomy_data <-
+  data.frame(rowname = rownames(counts))
+
+taxonomy_data <-
+  separate(taxonomy_data, "rowname", into_cols, sep = "\\|", fill = "right")
+
+rownames(counts) <-
+  gsub(".+\\|", "", rownames(counts))
+
+rownames(taxonomy_data) <-
+  gsub(".+\\|", "", rownames(counts))
+
+taxonomy_data <-
+  apply(taxonomy_data, 2, function(x) {gsub("[a-z]__", "", x)})
+
+taxonomy_data <-
+  data.frame(taxonomy_data)
+
+taxonomy_data <-
+  AnnotatedDataFrame(taxonomy_data)
+
+loman_MR <-
+  metagenomeSeq::newMRexperiment(
+    counts = counts,
+    phenoData = pheno_data,
+    featureData = taxonomy_data
+  )
+
 feature_order <- colnames(fData(loman_MR))
 mObj <- metavizr:::EpivizMetagenomicsDataInnerNodes$new(loman_MR, feature_order = feature_order)
 
 test_that("getValuesInnerNodes", {
   sampleId<- "OBK1122"
   res <- mObj$getValues(measurements = sampleId)
-  
+
   expected <- c(0.000 , 0.000, 1.2948, 499.0848, 0.000, 89.1858, 0.000, 0.000, 0.000, 0.000, 7.7368, 0.000, 0.000, 0.000, 0.000)
   diff_result <- setdiff(round(unname(res[[sampleId]]), digits=3), round(expected,digits=3))
   expect_equal(length(diff_result), 0)
@@ -20,18 +66,18 @@ test_that("getValuesInnerNodes", {
 
 test_that("getHierarchyInnerNodesRoot", {
   res <- mObj$getHierarchy(nodeId = NULL)
-  
+
   expect_equal("AllFeatures", as.character(res$tree$label))
   expect_equal(3, res$tree$nchildren)
 })
 
 test_that("getRowsInnerNodes", {
   sampleId<- "OBK1122"
-  resRows <- mObj$getRows(measurement = sampleId, selectedLevels = 2)  
-  expected_label <- c("Euryarchaeota", "Actinobacteria", "Bacteroidetes", 
-                      "Firmicutes", "Fusobacteria", "Proteobacteria", 
+  resRows <- mObj$getRows(measurement = sampleId, selectedLevels = 2)
+  expected_label <- c("Euryarchaeota", "Actinobacteria", "Bacteroidetes",
+                      "Firmicutes", "Fusobacteria", "Proteobacteria",
                       "Verrucomicrobia", "Viruses_noname")
-  
+
   intersect_result <- intersect(resRows$metadata$label, expected_label)
   expect_equal(length(intersect_result), length(expected_label))
 })

--- a/vignettes/IntroToMetavizr.Rmd
+++ b/vignettes/IntroToMetavizr.Rmd
@@ -228,11 +228,60 @@ In order to show this utility, we will use select portions of the vignette for a
 We first retrieve a dataset named `Zeller_2014` from curatedMetagenomicData and convert the ExpressionSet containing abundance measurements into an MRExperiment which we will then use with Metaviz.
 
 ```{r, eval=TRUE, echo=FALSE}
-require(curatedMetagenomicData)
+require(ExperimentHub)
+require(tidyr)
 
-zeller <- curatedMetagenomicData("ZellerG_2014.metaphlan_bugs_list.stool", dryrun = FALSE)
-zeller.eset <- zeller[[1]]
-zeller_MR_expr = ExpressionSet2MRexperiment(zeller.eset)
+EH <-
+  ExperimentHub()
+
+ZellerG_2014.metaphlan_bugs_list.stool <-
+    EH[["EH1954"]]
+
+relative_abundance <-
+  exprs(ZellerG_2014.metaphlan_bugs_list.stool)
+
+number_reads <-
+  ZellerG_2014.metaphlan_bugs_list.stool$number_reads
+
+counts <-
+  sweep(relative_abundance, 2, number_reads/100, "*")
+
+counts <-
+  round(counts)
+
+pheno_data <-
+  phenoData(ZellerG_2014.metaphlan_bugs_list.stool)
+
+into_cols <-
+  c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species", "Strain")
+
+taxonomy_data <-
+  data.frame(rowname = rownames(counts))
+
+taxonomy_data <-
+  separate(taxonomy_data, "rowname", into_cols, sep = "\\|", fill = "right")
+
+rownames(counts) <-
+  gsub(".+\\|", "", rownames(counts))
+
+rownames(taxonomy_data) <-
+  gsub(".+\\|", "", rownames(counts))
+
+taxonomy_data <-
+  apply(taxonomy_data, 2, function(x) {gsub("[a-z]__", "", x)})
+
+taxonomy_data <-
+  data.frame(taxonomy_data)
+
+taxonomy_data <-
+  AnnotatedDataFrame(taxonomy_data)
+
+zeller_MR_expr <-
+    metagenomeSeq::newMRexperiment(
+        counts = counts,
+        phenoData = pheno_data,
+        featureData = taxonomy_data
+    )
 ```
 
 We add the MRExperiment to the Metaviz app with a call to `plot` with the type = "innerNodeCounts" specified.


### PR DESCRIPTION
Hi @hcorrada, @lwaldron, these are the minimum changes necessary to get metavizr to pass for the upcoming Bioconductor 3.13 release. They will need to be pushed to the Bioconductor git server before Tuesday at 4:45 PM EST when the builds for release begin. It was necessary to take out references to `ExpressionSet2MRexperiment` because it has been removed from curatedMetagenomicData 3.0.0. I have actually removed curatedMetagenomicData altogether and just accessed the objects via ExperimentHub – this was a better strategy so I could make sure the results were identical to what they were before. I hope this helps and isn't too much hassle to push to the Bioconductor git server. Finally, the removal `ExpressionSet2MRexperiment` had more to do with how curatedMetagenomicData works now and we are still big fans of metavizr! Thanks, Lucas